### PR TITLE
Add initial Eclipse IDE description and Contribution instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to Eclipse
+
+Thanks for your interest in contributing to Eclipse.
+Contributions are more than welcome and are a great opportunity to join a vibrant community, learn new skills, and make a real impact!
+
+This document is intended to guide you through the general contribution process.
+Although each Eclipse project has its own specific workflow and rules, the basic initial steps are are the same in all cases
+
+1. [Creating an Eclipse Development Environment](#creating-an-eclipse-development-environment)
+2. [Setting up an Eclipse and GitHub Account and legal requirements](#setting-up-an-eclipse-and-github-account)
+3. [Submitting a contribution to a Eclipse project hosted at Github](#submitting-a-contribution-for-a-project-hosted-at-github)
+
+## Creating an Eclipse Development Environment
+
+To provision an Eclipse installation and workspace to work on Eclipse we recommend to use the Eclipse Installer powered by `Eclipse Oomph`.
+
+Most projects provide an _Oomph setup button_ prominently on their main page, similar to:
+[![Create Eclipse Development Environment for Eclipse Platform](https://download.eclipse.org/oomph/www/setups/svg/Eclipse_Platform.svg)](
+https://www.eclipse.org/setups/installer/?url=https://raw.githubusercontent.com/eclipse-platform/eclipse.platform/master/releng/org.eclipse.platform.setup/PlatformConfiguration.setup&show=true
+"Click to open Eclipse-Installer Auto Launch or drag into your running installer")
+
+The [`Provisioning tutorial`](https://wiki.eclipse.org/Eclipse_Platform_SDK_Provisioning) explains how to setup the full Eclipse development environment automatically using the _Oomph setup button_ of the desired project.
+
+## Setting up an Eclipse and GitHub Account
+
+Create an [Eclipse account](https://accounts.eclipse.org/) if you don't already have one. 
+See the ["Eclipse Foundation Account" section](https://www.eclipse.org/projects/handbook/#contributing-account) in the Eclipse Committer Handbook.
+
+All contributors must electronically sign the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
+via their [Eclipse account](https://accounts.eclipse.org/).
+For more information, please see the [Eclipse Committer Handbook](https://www.eclipse.org/projects/handbook/#contributing).
+
+To verify the Eclipse Contributor Agreement, GitHub contributions must use the 
+same email address like your [Eclipse account](https://accounts.eclipse.org/).
+If your GitHub account was registered with a different address, you can [add your Eclipse
+email address to the account](https://github.com/settings/emails) instead.
+
+The vast majority of projects contributing to the Eclipse IDE is hosted on [GitHub](https://github.com/).
+Therefore you need a Github account to contribute to these projects.
+You can also add your GitHub account name to your [Eclipse account](https://accounts.eclipse.org/) to enable automated management of access rights for Eclipse project members. 
+You can do this by logging into your Eclipse account, choosing ["Edit Profile"](https://accounts.eclipse.org/user/edit) and add your GitHub account name in the social media links section.
+
+To be able to push to your repository you should also add your [SSH public key to your GitHub account](https://github.com/settings/keys).
+Pushing via `https` is not recommended.
+
+## Submitting a contribution for a project hosted at Github
+
+The recommended way for contributions via GitHub is to create a fork of the main project repository and to create changes only in that fork
+(see [fork and pull model](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/about-collaborative-development-models#fork-and-pull-model)
+as well as [working with fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks) in the GitHub documentation).
+Then you can create a pull request (PR) from your fork to propose your changes for submission into the main project repository.
+
+See also
+- https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-forks
+- https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork
+- https://docs.github.com/en/get-started/getting-started-with-git/managing-remote-repositories

--- a/profile/README.md
+++ b/profile/README.md
@@ -2,5 +2,57 @@
 
 ![splash](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform/master/platform/org.eclipse.platform/splash.png)
 
+### WARNING
 This page is currently under construction and will become the starting-point for everyone interested in the development of the Eclipse IDE,
 including an exhaustive guide for contributors and information to find the right repository to report an issue.
+
+---
+
+Eclipse is the leading open platform for professional developers.
+
+Eclipse is famous for being an _Integrated Development Environment_ (IDE) for the _Java_™ programming language but is also well capable of other languages like C/C++, JavaScript or TypeScript, to just name a few.
+At its core Eclipse is a highly extensible platform and a comprehensive set of frameworks and common services that collectively provide a powerful software development infrastructure used for numerous free and open as well as for commercial products and applications.
+
+This page is intended to be the start for everyone interested in contributing to the Eclipse IDE.
+<br>
+Users of the Eclipse IDE should start at: https://eclipseide.org/
+
+## Developing and Contributing
+
+Thank you for your interest in contributing to Eclipse. Contributions are more than welcome!
+
+The [CONTRIBUTING](../CONTRIBUTING.md) section provides the information to guide you through the contribution process, after you have identified the project you want to contribute to.
+
+## Structure of the Eclipse IDE and its eco-system
+
+This section is intended to make you familiar with the general structure of Eclipse to help identifying the projects where you wants to report issues or contribute to.
+To find the projects of your interested see the [Project Discovery Guide](../projects.md).
+
+First of all there is not one single _Eclipse IDE_ or a single _Eclipse IDE_ project.
+In general the _Eclipse IDE_ is organized into numerous independent _Eclipse projects_.
+Each project can contribute multiple _components_ to an IDE.
+The _components_ of Eclipse are called `Plug-ins` and are grouped into `Features`.
+
+Most active projects release quarterly about the same time in a coordinated processes called the _Simultaneous Release_.
+
+The [Eclipse Download page](https://www.eclipse.org/downloads/packages/) provides various predefined _Eclipse IDE Packages_, each of them bundling a different set of Features and Plug-ins from the corresponding SimRel.
+Users can further customize their Eclipse IDE by installing more Features/Plug-ins from the [Simultaneous Release Repository](https://download.eclipse.org/releases/), the [Eclipse Marketplace](https://marketplace.eclipse.org/) or just any p2-Repository available for them.
+Undesired Features can also be uninstalled.
+
+## Community
+
+The _Eclipse IDE_ is an _Eclipse Community project_ and as such obeys the governance rules described in the [Eclipse Development Process](https://www.eclipse.org/projects/dev_process/) to guarantee meritocracry, diversity, vendor-neutrality and business-friendliness.
+
+Please bear in mind that the Eclipse IDE as a whole and the contributing projects are often developed by volunteers and the Eclipse IDE is not a product you contracted for.
+As a result, the contributors may not be able to look into some support requests.
+As per Eclipse Development Process, the committers are committed to review incoming code contributions though.
+If you do not provide the fix/implementation yourself (or pay someone to do it for you), a bug you reported might never get fixed.
+If it is a serious bug, other people than you might care enough to provide a fix.
+As a consequence of all that, the only sure way to ensure some issue gets fixed or some feature gets implemented is that you contribute it yourself and convince some contributor that the change you submit is in the best interest of the project.
+
+As you contribute more and more, you will eventually get nominated as a committer on the project.
+
+## Technical and reference documentation
+
+Comprehensive technical documentation of the different components can be found at
+- https://help.eclipse.org/latest/index.jsp

--- a/projects.md
+++ b/projects.md
@@ -1,0 +1,8 @@
+TODO: Make this a comprehensive guide about how to find the desired project and provide an overview about all available projects/repositories
+
+TODO: provide a list of all SimRel (or even all Eclipse projects), ideally something that's derived from EF PMI,
+but it should also help interested contributors to find the corresponding project.
+
+TODO: tips to identify the Plug-in of interest?
+- Alt+Shift+F1
+- Repository references encoded in Plug-in MANIFEST.MF files?!


### PR DESCRIPTION
This is an early draft of the (work in progress) initial Eclipse IDE description and Contribution instructions.

Many parts are highly inspired by https://github.com/eclipse-platform/.github but are generalized to be applicable for all projects forming the Eclipse-IDE