### PR TITLE
Remove D&D workaround for MacOS users

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Once you've downloaded the installer, proceed to the next step to install a proj
 
 Once you have the Eclipse Installer, you can set up both an IDE and a workspace containing the source-code of the project to contribute to. Each Eclipse project provides an individual _Setup_ file, which automates the installation and configuration process. See the [Project Guide](projects.md) for a list of Eclipse IDE projects. 
 
-**💡 Tip:** If you're on a Mac, check out the [additional installation instructions for Mac](InstallerAdvancedOptions.md#install-with-copypaste-for-macos-users).
+**💡 Tip:** If you're on a Mac, you're using the latest version of the installer, because there used to be problems with drag&drop.
 
 If you have not yet chosen a projec to contribute to, you can for example use the setup for **eclipse.platform.ui** [![Copy this link](https://img.shields.io/badge/Setup-orange)](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/releng/org.eclipse.ui.releng/platformUIConfiguration.setup "Drag this setup URL in the Eclipse installer Banner"). This will allow you to get familiar with the contribution process.
 

--- a/InstallerAdvancedOptions.md
+++ b/InstallerAdvancedOptions.md
@@ -1,21 +1,3 @@
-# Install with copy/paste (for macos users) 
-
-While the Drag & Drop issue on mac OS is not fixed ([See Issue 111](https://github.com/eclipse-oomph/oomph/issues/111)), or if you prefer to use the Copy/Paste method, proceed as follow:
-
-### Switching directly to Advanced Mode
-
-1. Start the Eclipse Installer.
-2. In the bottom-left corner of the window, click on the menu icon  ![image](https://github.com/user-attachments/assets/a33e872e-ad50-46b2-8ea8-431fc40e82a4) 
- and select "Advanced Mode" from the menu. 
-
-
-### Installing the Project
-
-1. Copy the URL of a project's setup file (see [projects.md](projects.md)) (right click on a setup button and select "Copy Link"). You can also use this one for **eclipse.platform.ui** [![Copy this link](https://img.shields.io/badge/Setup-orange)](https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.ui/master/releng/org.eclipse.ui.releng/platformUIConfiguration.setup "Right click to copy the provided link for eclipse.platform.ui").
-2. Once this URL is in the clipboard the 'Apply configuration from the clipboard' button will be displayed (see below), click in the button and follow the wizard:
-
-![Copy setup](images/InstallerCopySetup.jpg) 
-
 # Advanced variable configuration
 
 By default the installation, workspace and all git clones are located within the `Root install folder`.


### PR DESCRIPTION
The D&D bug on Mac has been fixed in Oomph via https://github.com/eclipse-oomph/oomph/issues/111.

@opcoach the fix should already be available in the latest version of the installer (one usually gets the latest milestone). Can you update your installer and verify this?
